### PR TITLE
Adding /fetch-score and /onboarding-status endpoints & Standardizing the project for a better integration with the frontend samples

### DIFF
--- a/sample-server/README.md
+++ b/sample-server/README.md
@@ -18,29 +18,30 @@ We highly recommend to follow the 0 rule for your implementations, where all sen
 Within this sample you will find the only call to a `/omni/` endpoint we recommend for you to have, it requires the usage of the `apikey`, all further calls must be done using only the generated `token` and be addresed to the `/0/omni` endpoints. 
 
 ## Prerequisites
-This sample requires [Python 3](https://www.python.org/downloads/) or superior with pip installed
+This sample requires [JAVA 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) with gradle installed
 
 ## Local Development
 
 ### Environment
-Rename `sample.env` file to `.env` and add your client details:
+Rename `application.properties.example` file to `application.properties` and add your api url, api key, clientId, and flowId details:
 
-```env
+```application.properties
 API_URL=https://demo-api.incodesmile.com
-API_KEY=you-api-key
-CLIENT_ID=your-client-id
-FLOW_ID=Flow Id from your Incode dashboard.
+API_KEY=yourapikey
+CLIENT_ID=yourclientId
+FLOW_ID=yourflowid
+server.port=3000
 ```
 
 ### Run Localy
-Using pip install all the dependencies
+Using gradle to install all the dependencies
 ```bash
-pip install -r requirements.txt
+gradle build
 ```
 
 Then start the local server with
 ```bash
-python3 server.py
+gradle bootRun
 ```
 
 The server will accept petitions on `http://localhost:3000/`
@@ -80,6 +81,6 @@ curl --location 'https://yourforwardingurl.app/webhook' \
 
 ## Dependencies
 
-* **python3**: Python is a high-level, general-purpose programming language.
+* **Java17**: Java is a high-level, general-purpose programming language.
 * **ngrok**: Unified ingress platform used to expose your local server to the internet.
-* **dotenv**: Used to access environment variables.
+* **gradle**: Used to access external dependencies, and to build and run the project.

--- a/sample-server/README.md
+++ b/sample-server/README.md
@@ -67,7 +67,7 @@ Now you should be able to visit the following routes to receive the associated p
 1. `https://yourforwardingurl.app/start`
 2. `https://yourforwardingurl.app/onboarding-url`
 3. `https://yourforwardingurl.app/onboarding-url?redirectionUrl=https%3A%2F%2Fexample.com%2F`
-4. `https://yourforwardingurl.app/fetch-score??interviewId=660ee696a9b89db96502d8db`
+4. `https://yourforwardingurl.app/fetch-score?interviewId=660ee696a9b89db96502d8db`
 
 ## Webhook
 We provide an example on how to read the data we send in the webhook calls, from here you could

--- a/sample-server/README.md
+++ b/sample-server/README.md
@@ -30,8 +30,9 @@ Rename `application.properties.example` file to `application.properties` and add
 ```application.properties
 API_URL=https://demo-api.incodesmile.com
 API_KEY=yourapikey
-CLIENT_ID=yourclientId
+CLIENT_ID=yourclientid
 FLOW_ID=yourflowid
+ADMIN_TOKEN=Needed for the webhooks and the polling calls from the frontend to be able to fetch Scores and auto-approve
 server.port=3000
 ```
 

--- a/sample-server/README.md
+++ b/sample-server/README.md
@@ -8,6 +8,8 @@
 
 - GET `/onboarding-url`: Calls incodes `/omni/start` and then with the token calls `/0/omni/onboarding-url` to retrieve the unique onboarding-url for the newly created session.
 
+- GET `/fetch-score` : Calls incodes `/omni/get/score` to retrieve the overall score of a finished onboarding session. Requires a valid interviewId as request param and the session token as request header.
+
 It can receive the optional query parameter `redirectUrl` to set where to redirect the user at the end of the flow.
 
 - POST `/webhook`: Example webhook that reads the json data and return it back a response, from here you could fetch scores or OCR data when the status is ONBOARDING_FINISHED
@@ -44,7 +46,11 @@ Then start the local server with
 gradle bootRun
 ```
 
-The server will accept petitions on `http://localhost:3000/`
+Or run it directly through tour preferred IDE
+
+The server will accept petitions on `http://localhost:3000/`.
+
+You can change the server port on the `application.properties` file but remember which port your frontend is accessing
 
 ### Expose the server to the internet for frontend testing with ngrok
 For your frontend to properly work in tandem with this server on your mobile phone for testing, you will need a public url with proper SSL configured, by far the easiest way to acchieve this with an ngrok account properly configured on your computer. You can visit `https://ngrok.com` to make a free account and do a quick setup.
@@ -61,6 +67,7 @@ Now you should be able to visit the following routes to receive the associated p
 1. `https://yourforwardingurl.app/start`
 2. `https://yourforwardingurl.app/onboarding-url`
 3. `https://yourforwardingurl.app/onboarding-url?redirectionUrl=https%3A%2F%2Fexample.com%2F`
+4. `https://yourforwardingurl.app/fetch-score??interviewId=660ee696a9b89db96502d8db`
 
 ## Webhook
 We provide an example on how to read the data we send in the webhook calls, from here you could

--- a/sample-server/README.md
+++ b/sample-server/README.md
@@ -20,8 +20,9 @@ We highly recommend to follow the 0 rule for your implementations, where all sen
 Within this sample you will find the only call to a `/omni/` endpoint we recommend for you to have, it requires the usage of the `apikey`, all further calls must be done using only the generated `token` and be addresed to the `/0/omni` endpoints. 
 
 ## Prerequisites
-This sample requires [JAVA 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) with gradle installed
+This sample requires [JAVA 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) with at least [gradle 7.3+](https://gradle.org/install/) installed.
 
+Gradle 7.3 is the first version that fully supports Java 17. Newer versions are also compatible with Java 17.
 ## Local Development
 
 ### Environment
@@ -37,21 +38,21 @@ server.port=3000
 ```
 
 ### Run Localy
-Using gradle to install all the dependencies
+Using gradle to install all the dependencies.
 ```bash
 gradle build
 ```
 
-Then start the local server with
+Then start the local server with.
 ```bash
 gradle bootRun
 ```
 
-Or run it directly through tour preferred IDE
+Or run it directly through tour preferred IDE.
 
 The server will accept petitions on `http://localhost:3000/`.
 
-You can change the server port on the `application.properties` file but remember which port your frontend is accessing
+You can change the server port on the `application.properties` file but remember which port your frontend is accessing.
 
 ### Expose the server to the internet for frontend testing with ngrok
 For your frontend to properly work in tandem with this server on your mobile phone for testing, you will need a public url with proper SSL configured, by far the easiest way to acchieve this with an ngrok account properly configured on your computer. You can visit `https://ngrok.com` to make a free account and do a quick setup.
@@ -90,5 +91,5 @@ curl --location 'https://yourforwardingurl.app/webhook' \
 ## Dependencies
 
 * **Java17**: Java is a high-level, general-purpose programming language.
+* **gradle7.3+**: Used to access external dependencies, and to build and run the project.
 * **ngrok**: Unified ingress platform used to expose your local server to the internet.
-* **gradle**: Used to access external dependencies, and to build and run the project.

--- a/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
@@ -80,15 +80,16 @@ public class IncodeController {
     }
 
     @GetMapping("/onboarding-url")
-    public Mono<Map<String, String>> createSessionWithRedirectUrl() {
+    public Mono<Map<String, Object>> createSessionWithRedirectUrl() {
         return createIncodeSession()
             .flatMap(omniStartResponse ->
                 getOnboardingUrl(omniStartResponse.token())
                     .map(onboardingUrlResponse -> {
-                        Map<String, String> response = Map.of(
+                        Map<String, Object> response = Map.of(
                                 "interviewId", omniStartResponse.interviewId(),
                                 "token", omniStartResponse.token(),
-                                "url", onboardingUrlResponse.url()
+                                "url", onboardingUrlResponse.url(),
+                                "success", true
                         );
                         return response;
                     })

--- a/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
@@ -20,16 +20,16 @@ public class IncodeController {
 
     private final Logger log = LoggerFactory.getLogger(IncodeController.class);
 
-    @Value("${incode.apikey}")
+    @Value("${API_KEY}")
     private String apiKey;
 
-    @Value("${incode.apiurl}")
+    @Value("${API_URL}")
     private String apiUrl;
 
-    @Value("${incode.configurationId}")
+    @Value("${FLOW_ID}")
     private String configurationId;
 
-    @Value("${incode.clientId}")
+    @Value("${CLIENT_ID}")
     private String clientId;
 
     private final WebClient webClient;

--- a/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
@@ -121,14 +121,13 @@ public class IncodeController {
                                 "success", true
                         );
                         return response;
-                    })
+                    }).onErrorResume(this::buildResponseError)
             );
     }
 
     @GetMapping("/fetch-score")
     public Mono<Map<String, Object>> getFetchScoreFromASession(@RequestParam String interviewId,
                                                                @RequestHeader("X-Token") String token) {
-
         return getScoreOfSession(interviewId, token)
                 .map(fetchScoreResponse -> {
                     Map<String, Object> response = Map.of(
@@ -136,7 +135,7 @@ public class IncodeController {
                             "success", true
                     );
                     return response;
-                });
+                }).onErrorResume(this::buildResponseError);
     }
 
     @GetMapping("onboarding-status")

--- a/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
@@ -32,6 +32,9 @@ public class IncodeController {
     @Value("${CLIENT_ID}")
     private String clientId;
 
+    @Value("${ADMIN_TOKEN}")
+    private String adminToken;
+
     private final WebClient webClient;
 
     public IncodeController() {

--- a/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
@@ -111,7 +111,7 @@ public class IncodeController {
 
     @GetMapping("/fetch-score")
     public Mono<Map<String, Object>> getFetchScoreFromASession(@RequestParam String interviewId,
-                                                               @RequestHeader("X-Incode-Hardware-Id") String token) {
+                                                               @RequestHeader("X-Token") String token) {
 
         return getScoreOfSession(interviewId, token)
                 .map(fetchScoreResponse -> {

--- a/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
@@ -68,6 +68,19 @@ public class IncodeController {
                 .bodyToMono(FetchOnboardingUrlResponse.class);
     }
 
+    public Mono<FetchScoreResponse> getScoreOfSession(String interviewId, String token) {
+        String url = apiUrl + "/omni/get/score?interviewId=" + interviewId;
+        log.info("Calling {}", url);
+
+        return webClient.get()
+                .uri(url)
+                .header("X-Incode-Hardware-Id", token)
+                .header("x-api-key", apiKey)
+                .header("api-version", "1.0")
+                .retrieve()
+                .bodyToMono(FetchScoreResponse.class);
+    }
+
     @GetMapping("/start")
     public Mono<Map<String, String>> createSession() {
         return createIncodeSession().map( omniStartResponse -> {
@@ -94,6 +107,20 @@ public class IncodeController {
                         return response;
                     })
             );
+    }
+
+    @GetMapping("/fetch-score")
+    public Mono<Map<String, Object>> getFetchScoreFromASession(@RequestParam String interviewId,
+                                                               @RequestHeader("X-Incode-Hardware-Id") String token) {
+
+        return getScoreOfSession(interviewId, token)
+                .map(fetchScoreResponse -> {
+                    Map<String, Object> response = Map.of(
+                            "score", fetchScoreResponse.overall().status(),
+                            "success", true
+                    );
+                    return response;
+                });
     }
 
     @PostMapping("/webhook")

--- a/sample-server/src/main/java/com/incode/tokenserver/models/FetchScoreResponse.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/models/FetchScoreResponse.java
@@ -1,0 +1,4 @@
+package com.incode.tokenserver.models;
+public record FetchScoreResponse (Overall overall) {
+    public record Overall (String value, String status){}
+}

--- a/sample-server/src/main/java/com/incode/tokenserver/models/OnboardingStatusResponse.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/models/OnboardingStatusResponse.java
@@ -1,0 +1,3 @@
+package com.incode.tokenserver.models;
+
+public record OnboardingStatusResponse (String onboardingStatus){}

--- a/sample-server/src/main/resources/application.properties.example
+++ b/sample-server/src/main/resources/application.properties.example
@@ -1,5 +1,4 @@
-incode.apikey=yourapikey
-incode.apiurl=yourapiurl
-incode.configurationId=yourconfigurationid
-incode.clientId=yourclientId
-
+API_URL=yourapiurl
+API_KEY=yourapikey
+CLIENT_ID=yourclientId
+FLOW_ID=yourflowid

--- a/sample-server/src/main/resources/application.properties.example
+++ b/sample-server/src/main/resources/application.properties.example
@@ -2,4 +2,5 @@ API_URL=yourapiurl
 API_KEY=yourapikey
 CLIENT_ID=yourclientId
 FLOW_ID=yourflowid
+ADMIN_TOKEN=Needed for the webhooks to be able to fetch Scores and auto-approve
 server.port=3000

--- a/sample-server/src/main/resources/application.properties.example
+++ b/sample-server/src/main/resources/application.properties.example
@@ -2,3 +2,4 @@ API_URL=yourapiurl
 API_KEY=yourapikey
 CLIENT_ID=yourclientId
 FLOW_ID=yourflowid
+server.port=3000


### PR DESCRIPTION
While doing the low-code integration tutorial from the developer docs, I saw that the Java sample project may need some updates. In summary, the updates are:

- Updating the /onboarding-url endpoint to return a Map of <String, Object> just to add a success boolean used on the main.js file in the frontend project. Since we are using a success variable in the frontend that is not part of the object's response in Java, the onboarding start was breaking.
- Adding the /fetch-score endpoint to the sample project to provide a complete workaround to a user in the frontend. Previously, the sample was breaking with a 404 error in the /finished page of the frontend.
- Adding the /onboarding-status endpoint to the sample project to provide a complete workaround to a user using the html-iframe-js sample project.
- Standardizing the responseError object to match the specifications of the frontends samples and also the node-js sample server.
- Updating application.properties adding ADMIN_TOKEN needed to the webhook and the polling calls of /onboarding-status endpoint.
- Updating the Readme.md of the project by adding new instructions for the new endpoint and removing the old Python instructions. 
- Finally, I've updated the application.properties.examples keys since it was not working correctly in the IncodeController.