### PR TITLE
Hotfix webook and fetch score endpoint

### DIFF
--- a/sample-server/build.gradle
+++ b/sample-server/build.gradle
@@ -16,7 +16,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 }

--- a/sample-server/src/main/java/com/incode/tokenserver/TokenServerApplication.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/TokenServerApplication.java
@@ -2,10 +2,6 @@ package com.incode.tokenserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 public class TokenServerApplication {

--- a/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
+++ b/sample-server/src/main/java/com/incode/tokenserver/controllers/IncodeController.java
@@ -72,7 +72,7 @@ public class IncodeController {
     }
 
     public Mono<FetchScoreResponse> getScoreOfSession(String interviewId, String token) {
-        String url = apiUrl + "/omni/get/score?interviewId=" + interviewId;
+        String url = apiUrl + "/omni/get/score?id=" + interviewId;
         log.info("Calling {}", url);
 
         return webClient.get()


### PR DESCRIPTION
Quick hotfix fixing two small issues related to:

- /fetchScore endpoint was using "interviewId" as request parameter, but I've realized that this name only work for requests using session token, if you try to use admin token it will fail.
- the webhook endpoint was struggling with a de-serialization error related to the use of a Mono in the request body. Searching about the issue, I found that we were using the spring-boot-starter-web dependency together with the spring-boot-starter-webflux, which was causing an error of "Cannot construct instance of `reactor.core.publisher.Mono` (no Creators, like default constructor, exist): abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information". For a quick fix, I just removed the spring-boot-starter-web dependency and some unsued imports from it.